### PR TITLE
refactor(hooks): remove dead rewrite_forge_p function

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -60,7 +60,7 @@
     "forge_md_sha256": "08de0437c61e395dc88672f1ccc0d2c302e23a6ff051ca74c8b36d50996c6caa",
     "forge_skill_md_sha256": "968e95a5f156ffdb2a3d61bc92aaf34dd579ec6e4a29e2edda212514f00bcf26",
     "hooks_json_sha256": "4a131a3b1ceee87b968b13f6365daaa9f3a249605f9b8836a3f6d68421038e64",
-    "forge_delegation_enforcer_sha256": "68a4ea6f670994ed18e6e7331dfe324ee76e2795a6c1c5e247b34512ec5ac385",
+    "forge_delegation_enforcer_sha256": "b7a9463ba50f631a240d9c71a6d58981786164ccb8809d3b5a4d31fa4b94122c",
     "forge_progress_surface_sha256": "d5b060c0776a84a3cf75b7b9d7a9ffffeb15412a1a792aa4391969902190cf1c",
     "validate_release_gate_sha256": "cce77224d7ff340f296f78e35efd3f073cea4e61f0065c97f1d7d53cb660faa9",
     "output_style_forge_sha256": "5740c9e2918b65225f5dda31c587aeb0fd4f3d93a61b653d491f8f4a4e87fc77",

--- a/hooks/forge-delegation-enforcer.sh
+++ b/hooks/forge-delegation-enforcer.sh
@@ -322,32 +322,6 @@ is_mutating() {
   return 1
 }
 
-# Rewrite a `forge … -p …` command with UUID + --verbose and output pipes.
-# Single call to gen_uuid per invocation.
-#
-# SENTINEL v2.3 FINDING-R16-L1: anchor the substitution to the *command head*,
-# not the first occurrence of "forge " anywhere in $cmd. `${cmd/forge /...}`
-# would land inside a preceding env-var value (e.g. `FOO="forge x" forge -p …`).
-# Approach: strip the leading `FOO=bar ` env-prefix, confirm the remainder
-# starts with `forge ` (already guaranteed by is_forge_p), rebuild by
-# concatenating env-prefix + rewritten head.
-rewrite_forge_p() {
-  local cmd uuid stripped env_prefix rewritten_body
-  cmd="$1"
-  uuid="$(gen_uuid)"
-  if ! validate_uuid "$uuid"; then
-    # Hard-fail rather than splice an unvalidated value into the shell command.
-    echo "forge-delegation-enforcer: refusing to inject malformed UUID" >&2
-    return 1
-  fi
-  stripped="$(strip_env_prefix "$cmd")"
-  env_prefix="${cmd%"$stripped"}"
-  # stripped is guaranteed by is_forge_p to match `^forge([[:space:]]|$)`.
-  rewritten_body="forge --conversation-id ${uuid} --verbose ${stripped#forge }"
-  local pipes=" 2> >(sed 's/^/[FORGE-LOG] /' >&2) | sed 's/^/[FORGE] /'"
-  printf '%s%s%s' "$env_prefix" "$rewritten_body" "$pipes"
-}
-
 decide_bash() {
   local tool_input_json cmd
   tool_input_json="$1"


### PR DESCRIPTION
## Summary
- Removes `rewrite_forge_p()` (26 lines + comment block) from `hooks/forge-delegation-enforcer.sh` — the function was never called; `decide_bash` duplicates its logic inline
- Eliminates a latent hazard: if ever reached, the function would call `gen_uuid` internally, producing a **second UUID** different from the one already validated at the `decide_bash` call site
- Updates `plugin.json` manifest SHA256 to match the modified file

## Test Plan
- [x] `tests/test_forge_enforcer_hook.bash` — 20/20 pass
- [x] `tests/test_plugin_integrity.bash` — 13/13 pass (SHA integrity check now passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)